### PR TITLE
Draft commit with a script to generate PDF using pandoc

### DIFF
--- a/IviDriverCore/1.0/Spec/IviDriverCore.md
+++ b/IviDriverCore/1.0/Spec/IviDriverCore.md
@@ -1,3 +1,15 @@
+---
+header-includes:
+  - \usepackage{enumitem}
+  - \setlistdepth{20}
+  - \renewlist{itemize}{itemize}{20}
+  - \renewlist{enumerate}{enumerate}{20}
+  - \setlist[itemize]{label=$\cdot$}
+  - \setlist[itemize,1]{label=\textbullet}
+  - \setlist[itemize,2]{label=--}
+  - \setlist[itemize,3]{label=*}
+---
+
 # IVI Driver Core Specification
 
 | Version Number | Date of Version    | Version Notes                  |


### PR DESCRIPTION
The scripts uses a docker hub docker package to generate the pdf file.

It appends a necessary header for Tex, and also fixes the  URLs in the Base spec.

However, the URL fixer is not general purpose.  Really need to specify the URL mapping for each MD file that is processed.  Also need to deal with the fact that here is a link in the NET file to something in the Documents directory.
