### PR TITLE
Added hyperlinks to the spec references

### DIFF
--- a/Generations/IVI 2026.md
+++ b/Generations/IVI 2026.md
@@ -24,8 +24,8 @@ Consistent with this direction, the related standards are in the IVI Foundation 
 
 | Standard | Description | Repository/file |
 |---|---|---|
-| IVI Driver Core Specification | The language-agnostic specification | InstrumentDriverSpecs/IviDriverCore/1.0/Spec/IviDriverCore.md |
-| IVI Driver .NET Specification | The language-specific requirements for Microsoft .NET drivers | InstrumentDriverSpecs/IviDriverNet/1.0/Spec/IviDriverNet.md |
+| IVI Driver Core Specification | The language-agnostic specification | [InstrumentDriverSpecs/IviDriverCore/1.0/Spec/IviDriverCore.md](https://github.com/IviFoundation/IviDrivers/blob/main/IviDriverCore/1.0/Spec/IviDriverCore.md) |
+| IVI Driver .NET Specification | The language-specific requirements for Microsoft .NET drivers | [InstrumentDriverSpecs/IviDriverNet/1.0/Spec/IviDriverNet.md](https://github.com/IviFoundation/IviDrivers/blob/main/IviDriverNet/1.0/Spec/IviDriverNet.md) |
 
 All IVI specifications are also available on the [IVI website](https://www.ivifoundation.org).
 


### PR DESCRIPTION
As stated in title.  The Generations table listed specific documents by referencing file locations, which is appropriate, but added hyperlinks for easy browsing.
