### PR TITLE
Added code owners to manage branching better

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# This file specifies the Code Owners that are referenced in the branch protection rules
+
+# Joe, Gabe, and Steve have open-ended permissions (first token is a wildcard)
+* @joseph-mueller
+* @GabeNI
+* @steve-schink
+
+# 2025-06-08 Each language developer has open permissions within their branch
+#    to do so, this line should identify the owner appropriately in each branch.


### PR DESCRIPTION
The branching rules can limit merges to code owners (with some caveats), so adding a code owner file to simplify ownership as we start 3 language specs in parallel.
