### PR TITLE
Fix PR Autorunner

### DIFF
--- a/IviDriverNet/1.0/Code/.azure/azure-pipelines.yml
+++ b/IviDriverNet/1.0/Code/.azure/azure-pipelines.yml
@@ -16,6 +16,15 @@ parameters:
     type: boolean
     default: true
 
+pr:
+  branches:
+    include:
+    - '*'
+    exclude:
+    - AnsiC*
+    - Python*
+    - Rust*
+
 trigger:
   branches:
     include:


### PR DESCRIPTION
Chage Azure YML so that PR to Python branch do not autorun the build actions for IVI.NET shared components.