### PR TITLE
Modify to not trigger build on PR for the language branches.

### DIFF
--- a/IviDriverNet/1.0/Code/.azure/azure-pipelines.yml
+++ b/IviDriverNet/1.0/Code/.azure/azure-pipelines.yml
@@ -16,6 +16,15 @@ parameters:
     type: boolean
     default: true
 
+pr:
+  branches:
+    include:
+    - '*'
+    exclude:
+    - AnsiC*
+    - Python*
+    - Rust*
+
 trigger:
   branches:
     include:


### PR DESCRIPTION
Per title.  THis will do builds on PRs.  THose builds were for the IVI.NET Shared Components which are not touched on this branch.